### PR TITLE
Make VIP show red on radar to Counter-Terrorists

### DIFF
--- a/cl_dll/hud/radar.cpp
+++ b/cl_dll/hud/radar.cpp
@@ -331,8 +331,8 @@ int CHudRadar::Draw(float flTime)
 		if( !FlashTime( flTime, &g_PlayerExtraInfo[i]) )
 			continue;
 
-		// player with C4 must be red
-		if( g_PlayerExtraInfo[i].has_c4 )
+		// player with C4 or VIP must be red
+		if( g_PlayerExtraInfo[i].has_c4 || g_PlayerExtraInfo[i].vip )
 		{
 			DrawUtils::UnpackRGB( r, g, b, RGB_REDISH );
 		}


### PR DESCRIPTION
On the steam version of cs1.6, the VIP on as_* maps shows red on the radar to the counter terrorists. This only requires one line of code to be changed. I am unable to get a screenshot of this however you can see this for yourself by simply starting a match on as_oilrig with bots (on steam cs16) and waiting until you are no longer the vip. This change is minor and can easily be done yourself.